### PR TITLE
Add GitHub URL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "rustlings-fix"
 authors = ["Jack Clayton"]
+homepage = "https://github.com/jackos/rustlings-fix"
 description = "Fixes rustlings exercises to work with rust-analyzer language server"
 license = "MIT"
 version = "0.1.1"


### PR DESCRIPTION
I know that the published package can have completely different code, but it still feels weird when a crate is missing the repository URL.